### PR TITLE
Update script to add timestamp in EXIF of images for support in cloud photo storage providers

### DIFF
--- a/download_memories.py
+++ b/download_memories.py
@@ -3,6 +3,7 @@ import requests
 import os
 import datetime
 import urllib
+import piexif
 
 from sys import exit
 from colorama import Fore
@@ -94,6 +95,18 @@ def downloadMemories(path):
             os.utime(filename, (timestamp, timestamp))
             if os.name=='nt':   ## only for windows overrite creation time
                 setctime(filename, timestamp)
+            
+            # Add date information to EXIF information of image for support in cloud services (Amazon Photos, Google Photos, etc.)
+            if not filetype == 'Video':
+                exif_dict = piexif.load(filename)
+                piexif.remove(filename)
+                new_date = datetime.datetime.fromtimestamp(timestamp).strftime("%Y:%m:%d %H:%M:%S")
+                exif_dict['0th'][piexif.ImageIFD.DateTime] = new_date
+                exif_dict['Exif'][piexif.ExifIFD.DateTimeOriginal] = new_date
+                exif_dict['Exif'][piexif.ExifIFD.DateTimeDigitized] = new_date
+                exif_bytes = piexif.dump(exif_dict)
+                piexif.insert(exif_bytes, filename)
+            
 
     print('\n\n----------------\n')
     success('Finished')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ win32_setctime==1.0.1
 requests==2.24.0
 tqdm==4.48.2
 colorama==0.4.3
+piexif==1.1.3 


### PR DESCRIPTION
Thanks for contributing this great library! I've added support for adding in the EXIF of the images the required fields for the date and time to show up correctly in cloud photo storage providers such as Amazon Photos and Google Photos. 